### PR TITLE
fix: incorrect `rel` attribute for Mastodon link (#875)

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -64,34 +64,41 @@
     {% endunless %}
 
     {% for entry in site.data.contact %}
-      {% capture url %}
-        {%- if entry.type == 'github' -%}
-          https://github.com/{{ site.github.username }}
-        {%- elsif entry.type == 'twitter' -%}
-          https://twitter.com/{{ site.twitter.username }}
-        {%- elsif entry.type == 'email' -%}
+
+      {% case entry.type %}
+        {% when 'github' %}
+          {% assign url = 'https://github.com/' | append: site.github.username %}
+        {% when 'twitter' %}
+          {% assign url = 'https://twitter.com/' | append: site.twitter.username %}
+        {% when 'email' %}
           {% assign email = site.social.email | split: '@' %}
-          javascript:location.href = 'mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@')
-        {%- elsif entry.type == 'rss' -%}
-          {{ "/feed.xml" | relative_url }}
-        {%- else -%}
-          {{ entry.url }}
-        {%- endif -%}
-      {% endcapture %}
+          {%- capture url -%}
+            javascript:location.href = 'mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@')
+          {%- endcapture -%}
+        {% when 'rss' %}
+          {% assign url = '/feed.xml' | relative_url %}
+        {% else %}
+          {% assign url = entry.url %}
+      {% endcase %}
 
       {% if url %}
       <a href="{{ url }}" aria-label="{{ entry.type }}"
-        {% assign link_types = nil %}
+        {% assign link_type = nil %}
+
         {% unless entry.noblank %}
-          {% assign link_types = link_types | append: " noopener" %}
+          {% if entry.type == 'mastodon' %}
+            {% assign link_type = "me" %}
+          {% else %}
+            {% assign link_type = "noopener" %}
+          {% endif %}
           target="_blank"
         {% endunless %}
 
         {% if entry.type == 'mastodon' %}
-          {% assign link_types = link_types | append: " me" %}
+          {% assign link_type = "me" %}
         {% endif %}
 
-        {% if link_types %}rel="{{ link_types | lstrip }}"{% endif %}>
+        {% if link_type %}rel="{{ link_type }}"{% endif %}>
         <i class="{{ entry.icon }}"></i>
       </a>
       {% endif %}


### PR DESCRIPTION
Close #875, #876